### PR TITLE
Add htmlspecialchars() on text to avoid invalid xml

### DIFF
--- a/classes/datatypes/ezstring/ezstringxmlexport.php
+++ b/classes/datatypes/ezstring/ezstringxmlexport.php
@@ -46,7 +46,7 @@ class eZStringXMLExport extends eZXMLExportDatatype
 
     protected function toXML()
     {
-        return $this->contentObjectAttribute->content();
+        return htmlspecialchars( $this->contentObjectAttribute->content() );
     }
 }
 ?>

--- a/classes/datatypes/eztext/eztextxmlexport.php
+++ b/classes/datatypes/eztext/eztextxmlexport.php
@@ -30,7 +30,7 @@ class eZTextXMLExport extends eZXMLExportDatatype
 
     protected function toXML()
     {
-        return $this->contentObjectAttribute->content();
+        return htmlspecialchars( $this->contentObjectAttribute->content() );
     }
 }
 ?>


### PR DESCRIPTION
Hello,

I have lots of content with character '&' and I always get invalid generated xml with ezxmlexport because this chars is not escaped (and is not allowed in xml).

I think the way to go is to use htmlspecialchars()  on ezstring and eztext datatype.
ezxml uses cdata so it's okay.

This works fine with my content.

Cheers
