### PR TITLE
Fixed issue #019459: eZ XML Export extension disables UP and DOWN class ...

### DIFF
--- a/design/admin2/templates/class/edit.tpl
+++ b/design/admin2/templates/class/edit.tpl
@@ -462,8 +462,9 @@ jQuery(function( $ )//called on document.ready
         inp2.val( inpv );
 
         // store with ajax request
-        var postVar = { 'ContentClassHasInput': 0 };
+        var postVar = { 'ContentClassHasInput': 0 }, _tokenNode = document.getElementById('ezxform_token_js');
         postVar[ param[0] ] = param[1];
+        if ( _tokenNode ) postVar['ezxform_token'] = _tokenNode.getAttribute('title');
         $.post( $('#ClassEdit').attr('action'), postVar, onDone );
         return false;
     });


### PR DESCRIPTION
...attribute re-order buttons

ezxmlexport override of edit.tpl was not implementing tokens.
Tested that in ezxmlexport 1.2 (eZP 4.4) the inclusion of unnecessary token input in form doesn't break the functionality, therefore, although the change is not required in pre 1.2 versions of the extension, for coherence of code, it seems harmless to commit it to master. 
